### PR TITLE
Hotfix/update acf pro

### DIFF
--- a/whippet.lock
+++ b/whippet.lock
@@ -24,7 +24,7 @@
         {
             "name": "advanced-custom-fields-pro",
             "src": "git@github.com:dxw-wordpress-plugins/advanced-custom-fields-pro",
-            "revision": "f9df07ea23fe38372e6bcf14cf8d06f25bd32714"
+            "revision": "7d42074d841d35d9e3f0cea550cd8647df14532b"
         }
     ]
 }


### PR DESCRIPTION
## Description

Hotfix update needed because PHP version issues prevent full prod deploy.

Patch plugin vulnerabilities 2024-06-26-095604
    
    https://patchstack.com/database/vulnerability/advanced-custom-fields-pro/wordpress-advanced-custom-fields-pro-plugin-6-3-2-contributor-broken-access-control-vulnerability?_a_id=329, https://patchstack.com/database/vulnerability/advanced-custom-fields-pro/wordpress-advanced-custom-fields-pro-6-3-2-subscriber-broken-access-control-vulnerability?_a_id=329, https://patchstack.com/database/vulnerability/advanced-custom-fields-pro/wordpress-advanced-custom-fields-pro-plugin-6-3-2-cross-site-request-forgery-csrf-vulnerability?_a_id=329

