### PR TITLE
Fix deprecation warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "11300:11300"
 
   beanstalkd_console:
-    image: agaveapi/beanstalkd-console
+    image: schickling/beanstalkd-console
     ports:
       - "2080:80"
     environment:

--- a/wp-content/themes/dxw-security-2017/composer.json
+++ b/wp-content/themes/dxw-security-2017/composer.json
@@ -31,7 +31,7 @@
         "post-update-cmd": "vendor/bin/phar-install"
     },
     "require": {
-        "dxw/pagination": "^1.0",
+        "dxw/pagination": "^1.0.1",
         "dxw/iguana": "^1.0",
         "dxw/iguana-theme": "^1.0",
         "dxw/iguana-extras": "^1.0",

--- a/wp-content/themes/dxw-security-2017/composer.lock
+++ b/wp-content/themes/dxw-security-2017/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b73a4b7c2394ca0c6cbc9f2e27a68c9",
+    "content-hash": "9de70b29059b26f33d3b5d030038f7cd",
     "packages": [
         {
             "name": "10up/wp_mock",
@@ -356,20 +356,20 @@
         },
         {
             "name": "dxw/pagination",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dxw/pagination.git",
-                "reference": "04100ff77902de9f269d8d4fcd908770e8fe400f"
+                "reference": "1ee37204fcf6d201a2935ff3aad4ff5de91a41b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dxw/pagination/zipball/04100ff77902de9f269d8d4fcd908770e8fe400f",
-                "reference": "04100ff77902de9f269d8d4fcd908770e8fe400f",
+                "url": "https://api.github.com/repos/dxw/pagination/zipball/1ee37204fcf6d201a2935ff3aad4ff5de91a41b8",
+                "reference": "1ee37204fcf6d201a2935ff3aad4ff5de91a41b8",
                 "shasum": ""
             },
             "require-dev": {
-                "phpunit/phpunit": "4.8.*"
+                "phpunit/phpunit": "^9.6.9"
             },
             "type": "library",
             "autoload": {
@@ -392,10 +392,10 @@
             "homepage": "https://github.com/dxw/pagination",
             "support": {
                 "issues": "https://github.com/dxw/pagination/issues",
-                "source": "https://github.com/dxw/pagination/tree/master"
+                "source": "https://github.com/dxw/pagination/tree/v1.0.1"
             },
             "abandoned": true,
-            "time": "2016-07-15T13:07:32+00:00"
+            "time": "2024-07-02T13:35:04+00:00"
         },
         {
             "name": "dxw/php-missing",
@@ -682,16 +682,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
@@ -702,7 +702,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -734,9 +734,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3655,16 +3655,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.1.1",
+            "version": "v7.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9b008f2d7b21c74ef4d0c3de6077a642bc55ece3"
+                "reference": "0aa29ca177f432ab68533432db0de059f39c92ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9b008f2d7b21c74ef4d0c3de6077a642bc55ece3",
-                "reference": "9b008f2d7b21c74ef4d0c3de6077a642bc55ece3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0aa29ca177f432ab68533432db0de059f39c92ae",
+                "reference": "0aa29ca177f432ab68533432db0de059f39c92ae",
                 "shasum": ""
             },
             "require": {
@@ -3728,7 +3728,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.1.1"
+                "source": "https://github.com/symfony/console/tree/v7.1.2"
             },
             "funding": [
                 {
@@ -3744,7 +3744,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:57:53+00:00"
+            "time": "2024-06-28T10:03:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3971,16 +3971,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.1.1",
+            "version": "v7.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "802e87002f919296c9f606457d9fa327a0b3d6b2"
+                "reference": "92a91985250c251de9b947a14bb2c9390b1a562c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/802e87002f919296c9f606457d9fa327a0b3d6b2",
-                "reference": "802e87002f919296c9f606457d9fa327a0b3d6b2",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/92a91985250c251de9b947a14bb2c9390b1a562c",
+                "reference": "92a91985250c251de9b947a14bb2c9390b1a562c",
                 "shasum": ""
             },
             "require": {
@@ -4017,7 +4017,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.1.1"
+                "source": "https://github.com/symfony/filesystem/tree/v7.1.2"
             },
             "funding": [
                 {
@@ -4033,7 +4033,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:57:53+00:00"
+            "time": "2024-06-28T10:03:55+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4848,16 +4848,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.1",
+            "version": "v7.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2"
+                "reference": "14221089ac66cf82e3cf3d1c1da65de305587ff8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/60bc311c74e0af215101235aa6f471bcbc032df2",
-                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2",
+                "url": "https://api.github.com/repos/symfony/string/zipball/14221089ac66cf82e3cf3d1c1da65de305587ff8",
+                "reference": "14221089ac66cf82e3cf3d1c1da65de305587ff8",
                 "shasum": ""
             },
             "require": {
@@ -4915,7 +4915,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.1"
+                "source": "https://github.com/symfony/string/tree/v7.1.2"
             },
             "funding": [
                 {
@@ -4931,7 +4931,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-04T06:40:14+00:00"
+            "time": "2024-06-28T09:27:18+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
This is to fix the deprecation warnings:
```
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest
version 2, schema 1 support is disabled by def
```
and 

<img width="1440" alt="image" src="https://github.com/dxw/advisories/assets/53922624/5098401a-02f4-46db-9f37-e60197524b7d">


## How to Test
2. Perform a search on the site
3. Confirm you are seeing the deprecation errors
4. Checkout this branch
5. Run:
```sh
cd wp-content/themes/dxw-security-2017; composer update -W
``` 
6. Refresh the page and confirm the errors are no longer present