### PR TITLE
Fix fatal error on Options page

### DIFF
--- a/wp-content/themes/dxw-security-2017/app/Posts/CustomFields.php
+++ b/wp-content/themes/dxw-security-2017/app/Posts/CustomFields.php
@@ -13,6 +13,10 @@ class CustomFields implements \Dxw\Iguana\Registerable
 
 	public function addPageTemplatesFields()
 	{
+		if (!function_exists('acf_add_local_field_group')) {
+			return;
+		}
+
 		acf_add_local_field_group([
 			'key' => 'group_59427d8ae4e29',
 			'title' => 'Page introduction',

--- a/wp-content/themes/dxw-security-2017/app/Theme/OptionsPage.php
+++ b/wp-content/themes/dxw-security-2017/app/Theme/OptionsPage.php
@@ -6,103 +6,107 @@ class OptionsPage implements \Dxw\Iguana\Registerable
 {
 	public function register()
 	{
-		acf_add_options_sub_page('Banner');
+		if (function_exists('acf_add_options_sub_page')) {
+			acf_add_options_sub_page('Banner');
+		}
 
 		// Hire us banner
-		acf_add_local_field_group([
-			'key' => 'group_5857b450d2170',
-			'title' => 'Call to action banner',
-			'fields' => [
-				[
-					'key' => 'field_5857b463ac3e9',
-					'label' => 'Header',
-					'name' => 'header',
-					'type' => 'text',
-					'instructions' => '',
-					'required' => 0,
-					'conditional_logic' => 0,
-					'wrapper' => [
-						'width' => '',
-						'class' => '',
-						'id' => '',
-					],
-					'default_value' => '',
-					'placeholder' => '',
-					'prepend' => '',
-					'append' => '',
-					'maxlength' => '',
-				],
-				[
-					'key' => 'field_5857b46dac3ea',
-					'label' => 'Content',
-					'name' => 'content',
-					'type' => 'wysiwyg',
-					'instructions' => '',
-					'required' => 0,
-					'conditional_logic' => 0,
-					'wrapper' => [
-						'width' => '',
-						'class' => '',
-						'id' => '',
-					],
-					'default_value' => '',
-					'tabs' => 'all',
-					'toolbar' => 'basic',
-					'media_upload' => 0,
-				],
-				[
-					'key' => 'field_5857b47dac3eb',
-					'label' => 'URL',
-					'name' => 'url',
-					'type' => 'url',
-					'instructions' => '',
-					'required' => 0,
-					'conditional_logic' => 0,
-					'wrapper' => [
-						'width' => '',
-						'class' => '',
-						'id' => '',
-					],
-					'default_value' => '',
-					'placeholder' => '',
-				],
-				[
-					'key' => 'field_5857b491ac3ec',
-					'label' => 'Call to action',
-					'name' => 'cta',
-					'type' => 'text',
-					'instructions' => '',
-					'required' => 0,
-					'conditional_logic' => 0,
-					'wrapper' => [
-						'width' => '',
-						'class' => '',
-						'id' => '',
-					],
-					'default_value' => '',
-					'placeholder' => '',
-					'prepend' => '',
-					'append' => '',
-					'maxlength' => '',
-				],
-			],
-			'location' => [
-				[
+		if (function_exists('acf_add_local_field_group')) {
+			acf_add_local_field_group([
+				'key'                   => 'group_5857b450d2170',
+				'title'                 => 'Call to action banner',
+				'fields'                => [
 					[
-						'param' => 'options_page',
-						'operator' => '==',
-						'value' => 'acf-options-banner',
+						'key'               => 'field_5857b463ac3e9',
+						'label'             => 'Header',
+						'name'              => 'header',
+						'type'              => 'text',
+						'instructions'      => '',
+						'required'          => 0,
+						'conditional_logic' => 0,
+						'wrapper'           => [
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						],
+						'default_value'     => '',
+						'placeholder'       => '',
+						'prepend'           => '',
+						'append'            => '',
+						'maxlength'         => '',
+					],
+					[
+						'key'               => 'field_5857b46dac3ea',
+						'label'             => 'Content',
+						'name'              => 'content',
+						'type'              => 'wysiwyg',
+						'instructions'      => '',
+						'required'          => 0,
+						'conditional_logic' => 0,
+						'wrapper'           => [
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						],
+						'default_value'     => '',
+						'tabs'              => 'all',
+						'toolbar'           => 'basic',
+						'media_upload'      => 0,
+					],
+					[
+						'key'               => 'field_5857b47dac3eb',
+						'label'             => 'URL',
+						'name'              => 'url',
+						'type'              => 'url',
+						'instructions'      => '',
+						'required'          => 0,
+						'conditional_logic' => 0,
+						'wrapper'           => [
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						],
+						'default_value'     => '',
+						'placeholder'       => '',
+					],
+					[
+						'key'               => 'field_5857b491ac3ec',
+						'label'             => 'Call to action',
+						'name'              => 'cta',
+						'type'              => 'text',
+						'instructions'      => '',
+						'required'          => 0,
+						'conditional_logic' => 0,
+						'wrapper'           => [
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						],
+						'default_value'     => '',
+						'placeholder'       => '',
+						'prepend'           => '',
+						'append'            => '',
+						'maxlength'         => '',
 					],
 				],
-			],
-			'menu_order' => 0,
-			'position' => 'normal',
-			'style' => 'default',
-			'label_placement' => 'top',
-			'instruction_placement' => 'label',
-			'hide_on_screen' => '',
-			'active' => 1,
-			'description' => '',
-		]);
+				'location'              => [
+					[
+						[
+							'param'    => 'options_page',
+							'operator' => '==',
+							'value'    => 'acf-options-banner',
+						],
+					],
+				],
+				'menu_order'            => 0,
+				'position'              => 'normal',
+				'style'                 => 'default',
+				'label_placement'       => 'top',
+				'instruction_placement' => 'label',
+				'hide_on_screen'        => '',
+				'active'                => 1,
+				'description'           => '',
+			]);
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes a PHP fatal error on the Options page when calling `acf_add_options_sub_page` without checking if the function exists:

```
PHP Fatal error:  Uncaught Error: Call to undefined function Dxw\DxwSecurity2017\Theme\acf_add_options_sub_page() in /var/www/html/wp-content/themes/dxw-security-2017/app/Theme/OptionsPage.php:9
```
It also adds the check for the Custom fields.