### PR TITLE
Fix missed ACF Fatal error

### DIFF
--- a/wp-content/themes/dxw-security-2017/app/Posts/CustomFields.php
+++ b/wp-content/themes/dxw-security-2017/app/Posts/CustomFields.php
@@ -319,6 +319,10 @@ class CustomFields implements \Dxw\Iguana\Registerable
 
 	public function addHomePageFields()
 	{
+		if (!function_exists('acf_add_local_field_group')) {
+			return;
+		}
+
 		acf_add_local_field_group([
 			'key' => 'group_5971ca59db830',
 			'title' => 'Homepage services',


### PR DESCRIPTION
## Description

This PR fixes the fatal error:

```
PHP Fatal error:  Uncaught Error: Call to undefined function Dxw\DxwSecurity2017\Posts\acf_add_local_field_group() in /var/www/html/wp-content/themes/dxw-security-2017/app/Posts/CustomFields.php:322
```