### PR TITLE
Fix _load_textdomain_just_in_time called incorrectly

### DIFF
--- a/wp-content/themes/dxw-security-2017/app/Theme/OptionsPage.php
+++ b/wp-content/themes/dxw-security-2017/app/Theme/OptionsPage.php
@@ -6,6 +6,11 @@ class OptionsPage implements \Dxw\Iguana\Registerable
 {
 	public function register()
 	{
+		add_action('acf/init', [$this, 'add_options_page']);
+	}
+
+	public function add_options_page(): void
+	{
 		if (function_exists('acf_add_options_sub_page')) {
 			acf_add_options_sub_page('Banner');
 		}


### PR DESCRIPTION
## Testing 

* Make sure you have define('WP_DEBUG_DISPLAY', true); in your config/server-local.php
* Spin up the local site on the `develop` branch
* You should see a notice like this either in your logs or on some pages:

> Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>acf</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later.

* Switch to this branch and check the error disappears 