### PR TITLE
Fix/minor errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,5 @@ wp-content/languages/
 /wp-content/plugins/classic-editor
 /wp-content/plugins/co-authors-plus
 /wp-content/plugins/page-excerpt
+/wp-content/plugins/query-monitor
 /wp-content/plugins/two-factor

--- a/whippet.json
+++ b/whippet.json
@@ -8,6 +8,7 @@
         {"name": "classic-editor", "ref": "v1"},
         {"name": "co-authors-plus", "ref": "v3"},
         {"name": "page-excerpt", "ref": "v1"},
+        {"name": "query-monitor", "ref": "v3"},
         {"name": "two-factor", "ref": "v0"}
     ]
 }

--- a/whippet.lock
+++ b/whippet.lock
@@ -1,20 +1,25 @@
 {
-    "hash": "b85cc521ae65368fc547cdf8de2c2c6b0494d2d7",
+    "hash": "2c5608f3f5277f03877b12f07fa22f5c89927431",
     "plugins": [
+        {
+            "name": "advanced-custom-fields-pro",
+            "src": "git@github.com:dxw-wordpress-plugins/advanced-custom-fields-pro",
+            "revision": "2a74fa2d7e8e4c61a8b02fe517a3ebb467b6219a"
+        },
         {
             "name": "akismet",
             "src": "git@github.com:dxw-wordpress-plugins/akismet",
-            "revision": "21bbcc97b63b8344622798b8daf9a7dd5f25baac"
+            "revision": "1e38fd260aa96e47a3c130fb691521d577d8641e"
         },
         {
             "name": "classic-editor",
             "src": "git@github.com:dxw-wordpress-plugins/classic-editor",
-            "revision": "d6b9f81757669b679f65f6f53f761bf791762282"
+            "revision": "7982979d76350e64a8ae60409526faa3b07cd662"
         },
         {
             "name": "co-authors-plus",
             "src": "git@github.com:dxw-wordpress-plugins/co-authors-plus",
-            "revision": "39a1582cf982f9fc58269ba4e2bcf0df0c388790"
+            "revision": "6939817e8feed817923a79b8532a38eb5b1f7d98"
         },
         {
             "name": "page-excerpt",
@@ -22,14 +27,14 @@
             "revision": "150fe6f26955a306d318b57354d11bc5f8a4868a"
         },
         {
-            "name": "two-factor",
-            "src": "git@github.com:dxw-wordpress-plugins/two-factor",
-            "revision": "c5485d0bcc71a379d767307bfadd4ba8530bdaae"
+            "name": "query-monitor",
+            "src": "git@github.com:dxw-wordpress-plugins/query-monitor",
+            "revision": "91e7a3eabf1fbf4b182f4a92972ba2375abed21f"
         },
         {
-            "name": "advanced-custom-fields-pro",
-            "src": "git@github.com:dxw-wordpress-plugins/advanced-custom-fields-pro",
-            "revision": "3384168e97dca7fe8ee4170e841743a059bc244a"
+            "name": "two-factor",
+            "src": "git@github.com:dxw-wordpress-plugins/two-factor",
+            "revision": "6b68b251cfb81232a7cfa2655e6853aeff7cd9fe"
         }
     ]
 }

--- a/wp-content/plugins/advisories-headers/CHANGELOG.md
+++ b/wp-content/plugins/advisories-headers/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* Explicitly do not cache preview pages
+
 ## [v1.0.0] - 2025-06-24
 
 ### Added

--- a/wp-content/plugins/advisories-headers/CHANGELOG.md
+++ b/wp-content/plugins/advisories-headers/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.0.1] - 2025-06-26
 
 ### Changed
 

--- a/wp-content/plugins/advisories-headers/advisories-headers.php
+++ b/wp-content/plugins/advisories-headers/advisories-headers.php
@@ -13,7 +13,7 @@
  * Plugin URI: https://github.com/dxw/advisories
  * Description: HTTP headers for the dxw Advisories site
  * Author: dxw
- * Version: 1.0.0
+ * Version: 1.0.1
  * Network: True
  */
 

--- a/wp-content/plugins/advisories-headers/spec/headers.spec.php
+++ b/wp-content/plugins/advisories-headers/spec/headers.spec.php
@@ -35,9 +35,19 @@ describe(\Dxw\AdvisoriesHeaders\Headers::class, function () {
 				expect($result)->toEqual($expected);
 			});
 		});
+		context('if the page is a preview page', function () {
+			it('does not cache the page', function () {
+				allow('is_user_logged_in')->toBeCalled()->andReturn(false);
+				allow('is_preview')->toBeCalled()->andReturn(true);
+				$expected = ['Cache-Control' => 'no-cache, private'];
+				$result = $this->headers->addCacheControl([]);
+				expect($result)->toEqual($expected);
+			});
+		});
 		context('if the user is not logged in and the request is a search query', function () {
 			it('caches the page with a short TTL', function () {
 				allow('is_user_logged_in')->toBeCalled()->andReturn(false);
+				allow('is_preview')->toBeCalled()->andReturn(false);
 				allow('is_search')->toBeCalled()->andReturn(true);
 				allow('is_front_page')->toBeCalled()->andReturn(false);
 				allow('is_archive')->toBeCalled()->andReturn(true);
@@ -49,6 +59,7 @@ describe(\Dxw\AdvisoriesHeaders\Headers::class, function () {
 		context('if the user is not logged in and the page is the homepage', function () {
 			it('caches the page with a short TTL', function () {
 				allow('is_user_logged_in')->toBeCalled()->andReturn(false);
+				allow('is_preview')->toBeCalled()->andReturn(false);
 				allow('is_search')->toBeCalled()->andReturn(false);
 				allow('is_front_page')->toBeCalled()->andReturn(true);
 				$expected = ['Cache-Control' => 'public, max-age=1800'];
@@ -59,6 +70,7 @@ describe(\Dxw\AdvisoriesHeaders\Headers::class, function () {
 		context('if the user is not logged in and the page is an archive page', function () {
 			it('caches the page with a short TTL', function () {
 				allow('is_user_logged_in')->toBeCalled()->andReturn(false);
+				allow('is_preview')->toBeCalled()->andReturn(false);
 				allow('is_search')->toBeCalled()->andReturn(false);
 				allow('is_front_page')->toBeCalled()->andReturn(false);
 				allow('is_archive')->toBeCalled()->andReturn(true);
@@ -70,6 +82,7 @@ describe(\Dxw\AdvisoriesHeaders\Headers::class, function () {
 		context('if the user is not logged in and the page is not the homepage or an archive page', function () {
 			it('does caches the page with a long TTL', function () {
 				allow('is_user_logged_in')->toBeCalled()->andReturn(false);
+				allow('is_preview')->toBeCalled()->andReturn(false);
 				allow('is_search')->toBeCalled()->andReturn(false);
 				allow('is_front_page')->toBeCalled()->andReturn(false);
 				allow('is_archive')->toBeCalled()->andReturn(false);

--- a/wp-content/plugins/advisories-headers/src/Headers.php
+++ b/wp-content/plugins/advisories-headers/src/Headers.php
@@ -25,7 +25,7 @@ class Headers
 	 */
 	public function addCacheControl(array $headers): array
 	{
-		if (is_user_logged_in()) {
+		if (is_user_logged_in() || is_preview()) {
 			$headers['Cache-Control'] = 'no-cache, private';
 		} elseif (is_front_page() || is_archive() || is_search()) {
 			$headers['Cache-Control'] = 'public, max-age=' . $this->ttl_short;

--- a/wp-content/plugins/dxw-sec-api/lib/Router.php
+++ b/wp-content/plugins/dxw-sec-api/lib/Router.php
@@ -18,6 +18,12 @@ class Router
         register_rest_route('v1', 'inspections/(?P<slug>'.$this->slug_regex.')', [
             'methods' => 'GET',
             'callback' => [$this->inspections_controller, 'show'],
+            'permission_callback' => [$this, 'checkPermission'],
         ]);
+    }
+
+    public function checkPermission(): bool
+    {
+        return true;
     }
 }

--- a/wp-content/themes/dxw-security-2017/app/Lib/PluginVersionChecker.php
+++ b/wp-content/themes/dxw-security-2017/app/Lib/PluginVersionChecker.php
@@ -7,7 +7,7 @@ class PluginVersionChecker
 	private int $id;
 	private array $versions;
 	private string $version;
-	private string $is_codex;
+	private bool $is_codex;
 	private string $codex_link;
 	private string $slug;
 

--- a/wp-content/themes/dxw-security-2017/app/Lib/PluginVersionChecker.php
+++ b/wp-content/themes/dxw-security-2017/app/Lib/PluginVersionChecker.php
@@ -9,7 +9,7 @@ class PluginVersionChecker
 	private string $version;
 	private bool $is_codex;
 	private string $codex_link;
-	private string $slug;
+	private string $slug = '';
 
 	public function __construct()
 	{


### PR DESCRIPTION
## Description

Fix some minor errors:

* Do not cache preview pages, explicitly
* Fix a type error in `PluginVersionChecker`
* Ensure that [`register_rest_route`](https://developer.wordpress.org/reference/functions/register_rest_route/) has a permissions callback
* FIX:
    Typed property Dxw\DxwSecurity2017\Lib\PluginVersionChecker::$slug
    must not be accessed before initialization in
    .../dxw-security-2017/app/Lib/PluginVersionChecker.php:106

## How to test

* Run the local site with `./script/server`
* Maybe go to http://localhost/wp-admin/plugins.php and activate Query Monitor
* Click around a few example posts, make sure that when you expand the "Old version" element it has sensible and correct version information
