### PR TITLE
FIX 404 link to CVSS specification

### DIFF
--- a/wp-content/themes/dxw-security-2017/templates/single-advisories.php
+++ b/wp-content/themes/dxw-security-2017/templates/single-advisories.php
@@ -72,10 +72,10 @@
                     </tr>
                 </tbody>
             </table>
-            <small>You can read more about CVSS base scores on <a href="http://en.wikipedia.org/wiki/CVSS">Wikipedia</a> or in the <a href="http://www.first.org/cvss/cvss-guide">CVSS specification</a>.</small>
+            <small>You can read more about CVSS base scores on <a href="http://en.wikipedia.org/wiki/CVSS">Wikipedia</a> or in the <a href="https://www.first.org/cvss/v2/guide">CVSS specification</a>.</small>
         </article>
         <?php endif; ?>
-        
+
         <article class="report">
             <h2>Proof of concept</h2>
             <div class="rich-text">


### PR DESCRIPTION
This link has been a 404 for some years. In addition, the specification has changed. This commit updates the link to version 2 of the specification, which is the latest one I can find that has "low, medium, high" and not just "low, high" metric values for the metrics we calculate.

Note (because it's easier to read than going to the files tab) we're replacing:

http://www.first.org/cvss/cvss-guide

with:

https://www.first.org/cvss/v2/guide
