### PR TITLE
Remove brew --no-lock CLI option

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -30,7 +30,7 @@ fi
 if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
 	if ! brew bundle check >/dev/null 2>&1; then
 		echo "==> Installing Homebrew dependencies..."
-		brew bundle install --verbose --no-lock
+		brew bundle install --verbose
 	fi
 fi
 


### PR DESCRIPTION
Brew no longer generates lockfiles.

See:
    https://github.com/Homebrew/homebrew-bundle/pull/1509
