### PR TITLE
Serve local dev env behind a global reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,8 @@ script/server -d
 
 Once the server has started, the following containers will be running:
 
-* WordPress: http://localhost (username/password: `admin`/`admin`)
+* WordPress: http://advisories.localhost (username/password: `admin`/`admin`)
 * MailCatcher: http://localhost:1080
-* Beanstalk Console: http://localhost:2080
-* MySQL: http://localhost:3306 (username/password: `root`/`foobar`)
 
 For a /bin/sh console running on the WordPress container, run `script/console`
 For a MySQL console, run `bin/wp db cli`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 volumes:
   mysql_data_dxw-security:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,28 +2,8 @@ volumes:
   mysql_data_advisories:
 
 services:
-  mailcatcher:
-    image: schickling/mailcatcher
-    ports:
-      - "1080:1080"
-
-  beanstalk:
-    image: schickling/beanstalkd
-    ports:
-      - "11300:11300"
-
-  beanstalkd_console:
-    image: schickling/beanstalkd-console
-    ports:
-      - "2080:80"
-    environment:
-      BEANSTALKD_HOST: beanstalk
-      BEANSTALKD_PORT: 11300
-
   mysql:
     image: mariadb:10
-    ports:
-      - "3306:3306"
     volumes:
       - mysql_data_advisories:/var/lib/mysql
     environment:
@@ -32,12 +12,19 @@ services:
 
   wordpress:
     image: thedxw/wpc-wordpress:php8.2
-    ports:
-      - "80:80"
-    links:
-      - mysql
-      - mailcatcher
-      - beanstalk
     volumes:
       - .:/usr/src/app
       - ./wp-content:/var/www/html/wp-content
+    networks:
+      - default
+      - traefik_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.advisories.rule=Host(`advisories.localhost`)"
+      - "traefik.http.routers.advisories.entrypoints=web"
+      - "traefik.docker.network=traefik_proxy"
+
+networks:
+  traefik_proxy:
+    external: true
+    name: traefik_proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 volumes:
-  mysql_data_dxw-security:
+  mysql_data_advisories:
 
 services:
   mailcatcher:
@@ -25,7 +25,7 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - mysql_data_dxw-security:/var/lib/mysql
+      - mysql_data_advisories:/var/lib/mysql
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_ROOT_PASSWORD: foobar

--- a/script/server
+++ b/script/server
@@ -4,6 +4,8 @@ set -e
 docker-compose down --remove-orphans
 docker-compose pull wordpress
 
+docker compose -p traefik_global -f traefik.yml up -d --no-recreate
+
 if test "$1" = "-d"; then
 	docker-compose up -d
 else

--- a/traefik.yml
+++ b/traefik.yml
@@ -1,0 +1,22 @@
+name: traefik_global
+
+networks:
+  traefik_proxy:
+    name: traefik_proxy
+
+services:
+  traefik:
+    image: traefik:v3.6
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - traefik_proxy
+
+  mailcatcher:
+    image: schickling/mailcatcher

--- a/wp-content/plugins/dxw-sec-api/composer.lock
+++ b/wp-content/plugins/dxw-sec-api/composer.lock
@@ -165,30 +165,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.4"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^14",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
             },
             "type": "library",
             "autoload": {
@@ -215,7 +214,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
             },
             "funding": [
                 {
@@ -231,7 +230,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2026-01-05T06:47:08+00:00"
         },
         {
             "name": "dxw/phar-install",


### PR DESCRIPTION
## Description

Serve the local env behind a global reverse proxy so we can run more than one local env at a time.

## How to test

1. Run `./script/setup && ./script/serve` 
2. Visit http://advisories.localhost
3. Go to Bikeshed repo, do the same thing and view http://bikeshed.localhost _while_ you have advisories open in your browser