### PR TITLE
docker-compose: By default bind only to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,17 @@ services:
   mailcatcher:
     image: schickling/mailcatcher
     ports:
-      - "1080:1080"
+      - "127.0.0.1:1080:1080"
 
   beanstalk:
     image: schickling/beanstalkd
     ports:
-      - "11300:11300"
+      - "127.0.0.1:11300:11300"
 
   beanstalkd_console:
     image: schickling/beanstalkd-console
     ports:
-      - "2080:80"
+      - "127.0.0.1:2080:80"
     environment:
       BEANSTALKD_HOST: beanstalk
       BEANSTALKD_PORT: 11300
@@ -25,7 +25,7 @@ services:
   mysql:
     image: mariadb:10
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     volumes:
       - mysql_data_dxw-security:/var/lib/mysql
     environment:
@@ -35,7 +35,7 @@ services:
   wordpress:
     image: thedxw/wpc-wordpress:php8.2
     ports:
-      - "80:80"
+      - "127.0.0.1:80:80"
     links:
       - mysql
       - mailcatcher


### PR DESCRIPTION
docker-compose: By default bind only to localhost

To avoid allowing the services to run on all available networks by default
bind the services to localhost.